### PR TITLE
use the latest keypress module, Deno.setRaw has been moved/replaced

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export { readKeypress } from 'https://deno.land/x/keypress@0.0.4/mod.ts';
+export { readKeypress } from 'https://deno.land/x/keypress@0.0.10/mod.ts';
 export * as color from 'https://deno.land/x/nanocolors@0.1.12/mod.ts';
 export * as ansi from 'https://deno.land/x/ansi@1.0.1/mod.ts';
 


### PR DESCRIPTION
Deno.setRaw has been moved to Deno.stdin.setRaw. This module won't work unless keypress dependency is bumped (which fixes this). 